### PR TITLE
Address MSVC 64-bit compile warnings.

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -162,7 +162,7 @@ static uint32 Hash32Len13to24(const char *s, size_t len) {
   uint32 d = Fetch32(s + (len >> 1));
   uint32 e = Fetch32(s);
   uint32 f = Fetch32(s + len - 4);
-  uint32 h = len;
+  uint32 h = static_cast<uint32>(len);
 
   return fmix(Mur(f, Mur(e, Mur(d, Mur(c, Mur(b, Mur(a, h)))))));
 }
@@ -175,11 +175,11 @@ static uint32 Hash32Len0to4(const char *s, size_t len) {
     b = b * c1 + v;
     c ^= b;
   }
-  return fmix(Mur(b, Mur(len, c)));
+  return fmix(Mur(b, Mur(static_cast<uint32>(len), c)));
 }
 
 static uint32 Hash32Len5to12(const char *s, size_t len) {
-  uint32 a = len, b = len * 5, c = 9, d = b;
+  uint32 a = static_cast<uint32>(len), b = a * 5, c = 9, d = b;
   a += Fetch32(s);
   b += Fetch32(s + len - 4);
   c += Fetch32(s + ((len >> 1) & 4));
@@ -194,7 +194,7 @@ uint32 CityHash32(const char *s, size_t len) {
   }
 
   // len > 24
-  uint32 h = len, g = c1 * len, f = g;
+  uint32 h = static_cast<uint32>(len), g = c1 * h, f = g;
   uint32 a0 = Rotate32(Fetch32(s + len - 4) * c1, 17) * c2;
   uint32 a1 = Rotate32(Fetch32(s + len - 8) * c1, 17) * c2;
   uint32 a2 = Rotate32(Fetch32(s + len - 16) * c1, 17) * c2;
@@ -299,7 +299,7 @@ static uint64 HashLen0to16(const char *s, size_t len) {
     uint8 b = s[len >> 1];
     uint8 c = s[len - 1];
     uint32 y = static_cast<uint32>(a) + (static_cast<uint32>(b) << 8);
-    uint32 z = len + (static_cast<uint32>(c) << 2);
+    uint32 z = static_cast<uint32>(len) + (static_cast<uint32>(c) << 2);
     return ShiftMix(y * k2 ^ z * k0) * k2;
   }
   return k2;
@@ -417,7 +417,7 @@ static uint128 CityMurmur(const char *s, size_t len, uint128 seed) {
   uint64 b = Uint128High64(seed);
   uint64 c = 0;
   uint64 d = 0;
-  signed long l = len - 16;
+  signed long l = static_cast<long>(len) - 16;
   if (l <= 0) {  // len <= 16
     a = ShiftMix(a * k1) * k1;
     c = b * k1 + HashLen0to16(s, len);


### PR DESCRIPTION
MSVC 2015 emitted a handful of truncation errors about implicitly converting
from a size_t length argument to a uint32 or long. These all look intentional or
benign. This commit adds casts to silence the warnings.

The errors addressed are:

```
3>external\city.cc(170): error C2220: warning treated as error - no 'object' file generated
3>external\city.cc(170): warning C4267: 'initializing': conversion from 'size_t' to 'uint32', possible loss of data
3>external\city.cc(183): warning C4267: 'argument': conversion from 'size_t' to 'uint32', possible loss of data
3>external\city.cc(187): warning C4267: 'initializing': conversion from 'size_t' to 'uint32', possible loss of data
3>external\city.cc(202): warning C4267: 'initializing': conversion from 'size_t' to 'uint32', possible loss of data
3>external\city.cc(307): warning C4267: 'initializing': conversion from 'size_t' to 'uint32', possible loss of data
3>external\city.cc(425): warning C4267: 'initializing': conversion from 'size_t' to 'long', possible loss of data
```
