### PR TITLE
Fix various compiler warnings (signedness conversion, 64-bit truncation)

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -162,7 +162,7 @@ static uint32 Hash32Len13to24(const char *s, size_t len) {
   uint32 d = Fetch32(s + (len >> 1));
   uint32 e = Fetch32(s);
   uint32 f = Fetch32(s + len - 4);
-  uint32 h = len;
+  uint32 h = static_cast<uint32>(len);
 
   return fmix(Mur(f, Mur(e, Mur(d, Mur(c, Mur(b, Mur(a, h)))))));
 }
@@ -172,14 +172,14 @@ static uint32 Hash32Len0to4(const char *s, size_t len) {
   uint32 c = 9;
   for (size_t i = 0; i < len; i++) {
     signed char v = s[i];
-    b = b * c1 + v;
+    b = b * c1 + static_cast<uint32>(v);
     c ^= b;
   }
-  return fmix(Mur(b, Mur(len, c)));
+  return fmix(Mur(b, Mur(static_cast<uint32>(len), c)));
 }
 
 static uint32 Hash32Len5to12(const char *s, size_t len) {
-  uint32 a = len, b = len * 5, c = 9, d = b;
+  uint32 a = static_cast<uint32>(len), b = a * 5, c = 9, d = b;
   a += Fetch32(s);
   b += Fetch32(s + len - 4);
   c += Fetch32(s + ((len >> 1) & 4));
@@ -194,7 +194,7 @@ uint32 CityHash32(const char *s, size_t len) {
   }
 
   // len > 24
-  uint32 h = len, g = c1 * len, f = g;
+  uint32 h = static_cast<uint32>(len), g = c1 * h, f = g;
   uint32 a0 = Rotate32(Fetch32(s + len - 4) * c1, 17) * c2;
   uint32 a1 = Rotate32(Fetch32(s + len - 8) * c1, 17) * c2;
   uint32 a2 = Rotate32(Fetch32(s + len - 16) * c1, 17) * c2;
@@ -295,11 +295,11 @@ static uint64 HashLen0to16(const char *s, size_t len) {
     return HashLen16(len + (a << 3), Fetch32(s + len - 4), mul);
   }
   if (len > 0) {
-    uint8 a = s[0];
-    uint8 b = s[len >> 1];
-    uint8 c = s[len - 1];
+    uint8 a = static_cast<uint8>(s[0]);
+    uint8 b = static_cast<uint8>(s[len >> 1]);
+    uint8 c = static_cast<uint8>(s[len - 1]);
     uint32 y = static_cast<uint32>(a) + (static_cast<uint32>(b) << 8);
-    uint32 z = len + (static_cast<uint32>(c) << 2);
+    uint32 z = static_cast<uint32>(len) + (static_cast<uint32>(c) << 2);
     return ShiftMix(y * k2 ^ z * k0) * k2;
   }
   return k2;
@@ -417,15 +417,15 @@ static uint128 CityMurmur(const char *s, size_t len, uint128 seed) {
   uint64 b = Uint128High64(seed);
   uint64 c = 0;
   uint64 d = 0;
-  signed long l = len - 16;
-  if (l <= 0) {  // len <= 16
+  if (len <= 16) {
     a = ShiftMix(a * k1) * k1;
     c = b * k1 + HashLen0to16(s, len);
     d = ShiftMix(a + (len >= 8 ? Fetch64(s) : c));
-  } else {  // len > 16
+  } else {
     c = HashLen16(Fetch64(s + len - 8) + k1, a);
     d = HashLen16(b + len, c + Fetch64(s + len - 16));
     a += d;
+    // len > 16 here, so do...while is safe
     do {
       a ^= ShiftMix(Fetch64(s) * k1) * k1;
       a *= k1;
@@ -434,8 +434,8 @@ static uint128 CityMurmur(const char *s, size_t len, uint128 seed) {
       c *= k1;
       d ^= c;
       s += 16;
-      l -= 16;
-    } while (l > 0);
+      len -= 16;
+    } while (len > 16);
   }
   a = HashLen16(a, c);
   b = HashLen16(d, b);

--- a/src/city.cc
+++ b/src/city.cc
@@ -171,7 +171,7 @@ static uint32 Hash32Len0to4(const char *s, size_t len) {
   uint32 b = 0;
   uint32 c = 9;
   for (size_t i = 0; i < len; i++) {
-    signed char v = s[i];
+    signed char v = static_cast<signed char>(s[i]);
     b = b * c1 + static_cast<uint32>(v);
     c ^= b;
   }


### PR DESCRIPTION
This came up when trying to enable more warnings in Chromium downstream.