### PR TITLE
city.cc: fix NetBSD support.

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -82,10 +82,8 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
 
 #include <sys/types.h>
 #include <machine/bswap.h>
-#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
 #define bswap_32(x) bswap32(x)
 #define bswap_64(x) bswap64(x)
-#endif
 
 #else
 


### PR DESCRIPTION
There's no need to probe for implementation-specific symbols.